### PR TITLE
Kwame asante sidebar

### DIFF
--- a/personalized-youtube/apps/web/components/site/Site.tsx
+++ b/personalized-youtube/apps/web/components/site/Site.tsx
@@ -15,6 +15,8 @@ export function Site() {
 
   const header = config.sections.filter((s) => HEADER_TYPES.has(s.type));
   const sidebar = config.sections.filter((s) => SIDEBAR_TYPES.has(s.type));
+  const leftSidebar = sidebar.filter((s) => s.type === 'Sidebar' && s.props.position !== 'right');
+  const rightSidebar = sidebar.filter((s) => s.type === 'Sidebar' && s.props.position === 'right');
   const main = config.sections.filter(
     (s) => !HEADER_TYPES.has(s.type) && !SIDEBAR_TYPES.has(s.type) && !ROOT_OVERLAY_TYPES.has(s.type),
   );
@@ -35,7 +37,7 @@ export function Site() {
         >{renderSection(section, config)}</div>
       ))}
       <div className="flex">
-        {sidebar.map((section) => (
+        {leftSidebar.map((section) => (
           <div
             key={section.id}
             data-section-id={section.id}
@@ -52,6 +54,14 @@ export function Site() {
             ))
           )}
         </main>
+        {rightSidebar.map((section) => (
+          <div
+            key={section.id}
+            data-section-id={section.id}
+            data-section-type={section.type}
+            style={chromeStyle}
+          >{renderSection(section, config)}</div>
+        ))}
       </div>
     </>
   );

--- a/personalized-youtube/apps/web/components/templates/Sidebar.tsx
+++ b/personalized-youtube/apps/web/components/templates/Sidebar.tsx
@@ -72,7 +72,8 @@ export function Sidebar({ section }: { section: Section; config: PageConfig }) {
   const channels = useMemo(() => uniqueChannels(config), [config]);
 
   if (section.type !== 'Sidebar') return null;
-  const { collapsed, pinnedItems, showSubscriptions } = section.props;
+  const { collapsed, pinnedItems, position, showSubscriptions } = section.props;
+  const edgeBorder = position === 'right' ? 'border-l' : 'border-r';
 
   function handleNavClick(item: string): void {
     if (!NAV_KEYS.has(item)) return;
@@ -87,7 +88,7 @@ export function Sidebar({ section }: { section: Section; config: PageConfig }) {
 
   return (
     <aside
-      className={`hidden lg:flex shrink-0 flex-col gap-1 overflow-y-auto border-r border-[color:var(--border)] bg-[color:var(--surface)] py-3 transition-all ${
+      className={`hidden lg:flex shrink-0 flex-col gap-1 overflow-y-auto ${edgeBorder} border-[color:var(--border)] bg-[color:var(--surface)] py-3 transition-all ${
         collapsed ? 'w-20 px-2 items-center' : 'w-60 px-3'
       }`}
       style={{ backdropFilter: `blur(var(--surface-blur))`, WebkitBackdropFilter: `blur(var(--surface-blur))` }}

--- a/personalized-youtube/apps/web/lib/prompts/editing-rules.ts
+++ b/personalized-youtube/apps/web/lib/prompts/editing-rules.ts
@@ -59,6 +59,12 @@ You: remove_section({ sectionId: 'shortsRow' })  (read the actual id from the sn
 Visitor: "compact mode"
 You: update_section({ sectionId: 'videoGrid', patch: { density: 'compact' } })
 
+Visitor: "move the sidebar to the right"
+You: update_section({ sectionId: 'sidebar', patch: { position: 'right' } })
+
+Visitor: "move the sidebar back to the left"
+You: update_section({ sectionId: 'sidebar', patch: { position: 'left' } })
+
 Visitor: "move recommendations to the top"
 You: reorder_sections({ order: ['topBar', 'recommendedRow', 'continueWatching', 'shortsRow', 'categoryChips', 'filterSummary', 'videoGrid', 'customNote'] })  (read actual ids from the snapshot; preserve TopBar+Sidebar ordering at the top)
 

--- a/personalized-youtube/apps/web/lib/prompts/schema-catalog.ts
+++ b/personalized-youtube/apps/web/lib/prompts/schema-catalog.ts
@@ -10,8 +10,9 @@ Top navigation. Props:
   - showProfileChip: boolean
 
 ### Sidebar
-Left navigation. Props:
+Navigation rail. Props:
   - collapsed: boolean — true hides labels, icon-only
+  - position: 'left' | 'right' — side of the page where the rail is docked
   - pinnedItems: string[] — labels of items pinned at top
   - showSubscriptions: boolean
 

--- a/personalized-youtube/packages/shared/src/schemas/sections.ts
+++ b/personalized-youtube/packages/shared/src/schemas/sections.ts
@@ -17,6 +17,7 @@ export const TopBar = baseSection('TopBar', {
 
 export const Sidebar = baseSection('Sidebar', {
   collapsed: z.boolean().default(false),
+  position: z.enum(['left', 'right']).default('left'),
   pinnedItems: z.array(z.string()).default(['Home', 'Shorts', 'Subscriptions', 'You']),
   showSubscriptions: z.boolean().default(true),
 });

--- a/personalized-youtube/scripts/patch-base-config.ts
+++ b/personalized-youtube/scripts/patch-base-config.ts
@@ -63,6 +63,7 @@ async function main() {
       type: 'Sidebar',
       props: {
         collapsed: false,
+        position: 'right',
         pinnedItems: ['Home', 'Shorts', 'Subscriptions', 'You'],
         showSubscriptions: true,
       },

--- a/personalized-youtube/scripts/seed.ts
+++ b/personalized-youtube/scripts/seed.ts
@@ -113,6 +113,7 @@ function makeBaseConfig(videos: Video[]): PageConfig {
         type: 'Sidebar',
         props: {
           collapsed: false,
+          position: 'right',
           pinnedItems: ['Home', 'Shorts', 'Subscriptions', 'You'],
           showSubscriptions: true,
         },


### PR DESCRIPTION
packages/shared/src/schemas/sections.ts
Added a position: 'left' | 'right' prop to the Sidebar schema so sidebar placement can be stored in page config.

apps/web/components/site/Site.tsx
Updated layout rendering to split sidebar sections into left and right groups, placing them before or after the main content based on props.position.

apps/web/components/templates/Sidebar.tsx
Updated the sidebar to read position and switch its divider between border-r and border-l depending on which side it is docked.

apps/web/lib/prompts/schema-catalog.ts
Documented the new sidebar position prop so the chat-editing system knows it is a valid configurable option.

apps/web/lib/prompts/editing-rules.ts
Added examples for moving the sidebar right or left using update_section.

scripts/seed.ts
Set the seeded default sidebar position to right.

scripts/patch-base-config.ts
Set the patched base config sidebar position to right so regenerated base configs preserve the intended layout.