### PR TITLE
Security: harden intercept adapters to match InnerTube posture

### DIFF
--- a/personalized-youtube/.env.example
+++ b/personalized-youtube/.env.example
@@ -24,5 +24,5 @@ FEED_ADAPTER=mock
 # Amazon intercept: default search query when home/chips load
 AMAZON_SEARCH_QUERY=best sellers
 
-# Dev-only flags
+# Dev-only flags (set false or omit in production — see docs/security.md)
 NEXT_PUBLIC_DEVTOOLS_ENABLED=true

--- a/personalized-youtube/DEPLOY.md
+++ b/personalized-youtube/DEPLOY.md
@@ -49,6 +49,8 @@ The build runs `pnpm --filter web build` per `vercel.json`. Output URL is printe
 
 ### Things to watch
 
+- **`FEED_ADAPTER=mock` in production** — live Amazon/Instagram/YouTube intercepts use the **server operator's** Chrome cookies, not each visitor's. See [`docs/security.md`](docs/security.md).
+- **`NEXT_PUBLIC_DEVTOOLS_ENABLED=false`** in production — prevents chat debug SSE from leaking system prompts to the browser.
 - `api/generate-content` has `maxDuration: 30` — Hobby plan caps function runtime at 10s. Pro plan gets 60s. If you're on Hobby and Haiku takes >10s, the request will be killed mid-stream. Mitigation: switch to Pro, or reduce `count` from 8 to 4 in `request_more_content`.
 - Cookies are `SameSite=Lax`. Visitors viewing through a third-party iframe (e.g., embedded somewhere) may not get a stable visitor_id.
 - The mock catalog (`apps/web/lib/mock-data/videos.json`) is bundled into the build. ~300 videos × ~600 bytes each = ~180KB JSON shipped to the server. Acceptable.

--- a/personalized-youtube/apps/web/app/api/amazon/more/route.ts
+++ b/personalized-youtube/apps/web/app/api/amazon/more/route.ts
@@ -1,17 +1,18 @@
 import { NextResponse } from 'next/server';
 import { getAmazonSearchMore } from '@/lib/amazon/client';
+import { INTERCEPT_TOKEN_MAX_LEN, interceptUnavailable } from '@/lib/intercept/api-response';
 
 export const runtime = 'nodejs';
 
 export async function GET(req: Request) {
   const url = new URL(req.url);
   const token = url.searchParams.get('token')?.trim() ?? '';
-  if (!token || token.length > 4096) {
+  if (!token || token.length > INTERCEPT_TOKEN_MAX_LEN) {
     return NextResponse.json({ ok: false, reason: 'invalid token' }, { status: 400 });
   }
   const result = await getAmazonSearchMore(token);
   if (result.kind !== 'ok') {
-    return NextResponse.json({ ok: false, reason: result.reason ?? 'unavailable' }, { status: 502 });
+    return interceptUnavailable(result.reason);
   }
   return NextResponse.json({
     ok: true,

--- a/personalized-youtube/apps/web/app/api/amazon/product/route.ts
+++ b/personalized-youtube/apps/web/app/api/amazon/product/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getAmazonProductDetail } from '@/lib/amazon/product-detail';
+import { interceptUnavailable } from '@/lib/intercept/api-response';
 
 export const runtime = 'nodejs';
 
@@ -11,7 +12,7 @@ export async function GET(req: Request) {
   }
   const result = await getAmazonProductDetail(asin);
   if (result.kind !== 'ok') {
-    return NextResponse.json({ ok: false, reason: result.reason ?? 'unavailable' }, { status: 502 });
+    return interceptUnavailable(result.reason);
   }
   return NextResponse.json({ ok: true, product: result.product });
 }

--- a/personalized-youtube/apps/web/app/api/amazon/reviews/route.ts
+++ b/personalized-youtube/apps/web/app/api/amazon/reviews/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getAmazonProductReviews } from '@/lib/amazon/client';
+import { interceptUnavailable } from '@/lib/intercept/api-response';
 
 export const runtime = 'nodejs';
 
@@ -11,7 +12,7 @@ export async function GET(req: Request) {
   }
   const result = await getAmazonProductReviews(asin);
   if (result.kind !== 'ok') {
-    return NextResponse.json({ ok: false, reason: result.reason ?? 'unavailable' }, { status: 502 });
+    return interceptUnavailable(result.reason);
   }
   return NextResponse.json({ ok: true, reviews: result.reviews });
 }

--- a/personalized-youtube/apps/web/app/api/amazon/search/route.ts
+++ b/personalized-youtube/apps/web/app/api/amazon/search/route.ts
@@ -1,14 +1,18 @@
 import { NextResponse } from 'next/server';
 import { getAmazonSearchFeed } from '@/lib/amazon/client';
+import { INTERCEPT_QUERY_MAX_LEN, interceptUnavailable } from '@/lib/intercept/api-response';
 
 export const runtime = 'nodejs';
 
 export async function GET(req: Request) {
   const url = new URL(req.url);
   const q = url.searchParams.get('q')?.trim() ?? '';
+  if (q.length > INTERCEPT_QUERY_MAX_LEN) {
+    return NextResponse.json({ ok: false, reason: 'invalid query' }, { status: 400 });
+  }
   const result = await getAmazonSearchFeed(q || undefined);
   if (result.kind !== 'ok') {
-    return NextResponse.json({ ok: false, reason: result.reason ?? 'unavailable' }, { status: 502 });
+    return interceptUnavailable(result.reason);
   }
   return NextResponse.json({
     ok: true,

--- a/personalized-youtube/apps/web/app/api/chat/route.ts
+++ b/personalized-youtube/apps/web/app/api/chat/route.ts
@@ -6,6 +6,7 @@ import { buildSystemBlocks, buildVisitorState } from '@/lib/prompts/system';
 import { TOOL_DEFINITIONS, siteById, siteBySlug, type Patch } from '@showcase/shared';
 import { supabaseAdmin } from '@/lib/supabase';
 import { getRenderedConfig } from '@/lib/queries/page';
+import { chatDebugEventsEnabled, isAllowedOutboundImageUrl } from '@/lib/intercept/security';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -116,7 +117,7 @@ export async function POST(req: NextRequest) {
     ];
     const lower = message.toLowerCase();
     const wantsVision = VISION_KEYWORDS.some((k) => lower.includes(k));
-    if (wantsVision && watching.thumbnail) {
+    if (wantsVision && watching.thumbnail && isAllowedOutboundImageUrl(watching.thumbnail)) {
       const img = await fetchAsImageBlock(watching.thumbnail);
       if (img) userBlocks.push(img);
     }
@@ -132,6 +133,10 @@ export async function POST(req: NextRequest) {
     async start(controller) {
       const enc = new TextEncoder();
       const send = (obj: unknown) => controller.enqueue(enc.encode(`data: ${JSON.stringify(obj)}\n\n`));
+      const debug = chatDebugEventsEnabled();
+      const sendDebug = (obj: unknown) => {
+        if (debug) send(obj);
+      };
 
       const t0 = Date.now();
       const toolUses: Array<{ name: string; input: unknown }> = [];
@@ -273,13 +278,13 @@ export async function POST(req: NextRequest) {
           tools: TOOL_DEFINITIONS,
           messages,
         };
-        send({ kind: 'debug_request', payload: requestPayload });
+        sendDebug({ kind: 'debug_request', payload: requestPayload });
 
         try {
           const response = anthropic.messages.stream(requestPayload as any);
 
           for await (const ev of response) {
-            send({ kind: 'debug_stream_event', payload: ev });
+            sendDebug({ kind: 'debug_stream_event', payload: ev });
             if (ev.type === 'message_start') lastMessageId = ev.message.id;
             if (ev.type === 'content_block_start' && ev.content_block.type === 'tool_use') {
               send({ kind: 'tool_use', name: ev.content_block.name });
@@ -295,7 +300,7 @@ export async function POST(req: NextRequest) {
 
           const finalMessage = await response.finalMessage();
           finalUsage = finalMessage.usage;
-          send({ kind: 'debug_final', payload: { content: finalMessage.content, usage: finalUsage, stop_reason: stopReason } });
+          sendDebug({ kind: 'debug_final', payload: { content: finalMessage.content, usage: finalUsage, stop_reason: stopReason } });
 
           for (const block of finalMessage.content) {
             if (block.type === 'text') {

--- a/personalized-youtube/apps/web/app/api/instagram/comments/route.ts
+++ b/personalized-youtube/apps/web/app/api/instagram/comments/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getInstagramMediaComments } from '@/lib/instagram/client';
+import { interceptUnavailable } from '@/lib/intercept/api-response';
 
 export const runtime = 'nodejs';
 
@@ -11,7 +12,7 @@ export async function GET(req: Request) {
   }
   const result = await getInstagramMediaComments(id);
   if (result.kind !== 'ok') {
-    return NextResponse.json({ ok: false, reason: result.reason ?? 'unavailable' }, { status: 502 });
+    return interceptUnavailable(result.reason);
   }
   return NextResponse.json({
     ok: true,

--- a/personalized-youtube/apps/web/app/api/instagram/more/route.ts
+++ b/personalized-youtube/apps/web/app/api/instagram/more/route.ts
@@ -1,17 +1,18 @@
 import { NextResponse } from 'next/server';
 import { getInstagramTimelineMore } from '@/lib/instagram/client';
+import { INTERCEPT_TOKEN_MAX_LEN, interceptUnavailable } from '@/lib/intercept/api-response';
 
 export const runtime = 'nodejs';
 
 export async function GET(req: Request) {
   const url = new URL(req.url);
   const token = url.searchParams.get('token')?.trim() ?? '';
-  if (!token || token.length > 4096) {
+  if (!token || token.length > INTERCEPT_TOKEN_MAX_LEN) {
     return NextResponse.json({ ok: false, reason: 'invalid token' }, { status: 400 });
   }
   const result = await getInstagramTimelineMore(token);
   if (result.kind !== 'ok') {
-    return NextResponse.json({ ok: false, reason: result.reason ?? 'unavailable' }, { status: 502 });
+    return interceptUnavailable(result.reason);
   }
   return NextResponse.json({
     ok: true,

--- a/personalized-youtube/apps/web/app/api/instagram/search/route.ts
+++ b/personalized-youtube/apps/web/app/api/instagram/search/route.ts
@@ -1,17 +1,18 @@
 import { NextResponse } from 'next/server';
 import { getInstagramSearchFeed } from '@/lib/instagram/client';
+import { INTERCEPT_QUERY_MAX_LEN, interceptUnavailable } from '@/lib/intercept/api-response';
 
 export const runtime = 'nodejs';
 
 export async function GET(req: Request) {
   const url = new URL(req.url);
   const q = url.searchParams.get('q')?.trim() ?? '';
-  if (q.length > 256) {
+  if (q.length > INTERCEPT_QUERY_MAX_LEN) {
     return NextResponse.json({ ok: false, reason: 'invalid query' }, { status: 400 });
   }
   const result = await getInstagramSearchFeed(q);
   if (result.kind !== 'ok') {
-    return NextResponse.json({ ok: false, reason: result.reason ?? 'unavailable' }, { status: 502 });
+    return interceptUnavailable(result.reason);
   }
   return NextResponse.json({
     ok: true,

--- a/personalized-youtube/apps/web/lib/amazon/client.ts
+++ b/personalized-youtube/apps/web/lib/amazon/client.ts
@@ -3,6 +3,11 @@
 // Replays the same request shape as amazon.com search: GET /s?k=… with the
 // user's Chrome session cookies. Parses product cards from the HTML response.
 // Capture reference: DevTools → Network → document or xhr on /s?k=…
+//
+// Tolerance contract (matches lib/innertube/client.ts):
+//   - Returns discriminated unions; no throws from public functions.
+//   - Cookie values are never logged. Count-only via chrome-cookies.
+//   - Chrome cookies belong to the server machine, not the site visitor.
 
 import type { Video } from '@showcase/shared';
 import {

--- a/personalized-youtube/apps/web/lib/instagram/client.ts
+++ b/personalized-youtube/apps/web/lib/instagram/client.ts
@@ -4,6 +4,11 @@
 //   GET https://www.instagram.com/api/v1/feed/timeline/…
 // Auth: Chrome cookies (sessionid, csrftoken, ds_user_id). Capture reference in
 // DevTools while logged in on instagram.com → filter "timeline".
+//
+// Tolerance contract (matches lib/innertube/client.ts):
+//   - Returns discriminated unions; no throws from public functions.
+//   - Cookie values are never logged. Count-only via chrome-cookies.
+//   - Upstream error bodies are not forwarded in reason strings.
 
 import type { Video } from '@showcase/shared';
 import {
@@ -11,6 +16,7 @@ import {
   readInstagramCookies,
 } from '../innertube/chrome-cookies';
 import { cookieValue, fetchWithSession } from '../intercept/browser-fetch';
+import { logInterceptFailure } from '../intercept/security';
 
 export type InstagramComment = {
   id: string;
@@ -191,7 +197,8 @@ async function fetchInstagramJson(
     });
     if (!res.ok) {
       const snippet = (await res.text()).slice(0, 200);
-      return { ok: false, reason: `instagram HTTP ${res.status}: ${snippet}` };
+      logInterceptFailure('instagram', `HTTP ${res.status}: ${snippet}`);
+      return { ok: false, reason: `instagram HTTP ${res.status}` };
     }
     return { ok: true, json: await res.json() };
   } catch (err) {

--- a/personalized-youtube/apps/web/lib/intercept/api-response.ts
+++ b/personalized-youtube/apps/web/lib/intercept/api-response.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+import { sanitizePublicReason } from './security';
+
+/** Standard 502 for intercept adapter failures (matches /api/yt/* posture). */
+export function interceptUnavailable(reason?: string, status = 502): NextResponse {
+  return NextResponse.json({ ok: false, reason: sanitizePublicReason(reason) }, { status });
+}
+
+export const INTERCEPT_QUERY_MAX_LEN = 256;
+export const INTERCEPT_TOKEN_MAX_LEN = 4096;

--- a/personalized-youtube/apps/web/lib/intercept/security.ts
+++ b/personalized-youtube/apps/web/lib/intercept/security.ts
@@ -1,0 +1,71 @@
+// Shared security helpers for intercept adapters (Amazon, Instagram, YouTube).
+//
+// Matches the innertube tolerance contract:
+//   - Cookie values are never logged or returned to clients.
+//   - Upstream HTML/JSON bodies stay server-side.
+//   - Public error strings are short and non-sensitive.
+
+const PUBLIC_REASON_MAX = 120;
+
+/** Mask a secret-ish string for server-side logs only. */
+export function maskSecretForLog(s: string): string {
+  if (s.length === 0) return '';
+  if (s.length <= 4) return '*'.repeat(s.length);
+  return `${s.slice(0, 2)}${'*'.repeat(Math.max(0, s.length - 4))}${s.slice(-2)}`;
+}
+
+/**
+ * Strip sensitive upstream payloads before returning adapter errors to the browser.
+ * Innertube already uses short reason codes; Amazon/IG must not forward HTML bodies.
+ */
+export function sanitizePublicReason(reason: string | undefined): string {
+  if (!reason?.trim()) return 'unavailable';
+  const trimmed = reason.trim();
+  if (trimmed.length <= PUBLIC_REASON_MAX && !looksSensitive(trimmed)) {
+    return trimmed;
+  }
+  if (looksSensitive(trimmed)) return 'intercept unavailable';
+  return `${trimmed.slice(0, PUBLIC_REASON_MAX)}…`;
+}
+
+function looksSensitive(s: string): boolean {
+  if (/<[a-z!/]/i.test(s)) return true;
+  if (/sessionid|csrftoken|set-cookie|cookie:/i.test(s)) return true;
+  if (/Bearer\s+\S/i.test(s)) return true;
+  return false;
+}
+
+/** Log intercept failure details server-side without leaking secrets to the client. */
+export function logInterceptFailure(scope: string, detail: string): void {
+  const safe =
+    detail.length > 240 ? `${maskSecretForLog(detail.slice(0, 120))}…(${detail.length} chars)` : detail;
+  console.warn(`[${scope}] ${safe}`);
+}
+
+/** Block SSRF when fetching thumbnails for multimodal chat (OWASP A10). */
+export function isAllowedOutboundImageUrl(raw: string): boolean {
+  try {
+    const u = new URL(raw);
+    if (u.protocol !== 'https:') return false;
+    const host = u.hostname.toLowerCase();
+    const allowedSuffixes = [
+      '.googleusercontent.com',
+      '.ytimg.com',
+      '.ggpht.com',
+      '.media-amazon.com',
+      '.cdninstagram.com',
+      '.fbcdn.net',
+      '.pravatar.cc',
+    ];
+    return allowedSuffixes.some((s) => host.endsWith(s) || host === s.slice(1));
+  } catch {
+    return false;
+  }
+}
+
+export function chatDebugEventsEnabled(): boolean {
+  if (process.env.NODE_ENV === 'production') {
+    return process.env.NEXT_PUBLIC_DEVTOOLS_ENABLED === 'true';
+  }
+  return process.env.NEXT_PUBLIC_DEVTOOLS_ENABLED !== 'false';
+}

--- a/personalized-youtube/apps/web/package.json
+++ b/personalized-youtube/apps/web/package.json
@@ -19,7 +19,7 @@
     "@supabase/supabase-js": "^2.45.0",
     "better-sqlite3": "12.9.0",
     "clsx": "^2.1.0",
-    "next": "^15.0.0",
+    "next": "^15.5.18",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-rnd": "^10.5.3",

--- a/personalized-youtube/docs/decisions.md
+++ b/personalized-youtube/docs/decisions.md
@@ -95,3 +95,14 @@ Append-only. Every domain agent (schema-keeper, api-keeper, db-keeper, etc.) app
   Why: covers aesthetic + behavioral personalization. `request_more_content` solves arbitrary-niche-query coverage when mock catalog is thin.
 - Decision: 8 specialist subagents in `.claude/agents/` (research-runner, schema-keeper, template-author, api-keeper, db-keeper, feed-curator, youtube-adapter, debugger) + cache-doctor. Main session is orchestrator only.
   Why: prevent context bloat across multi-week build. Each agent owns disjoint slice; main session sees only summaries.
+
+## 2026-05-20 — intercept security hardening (Amazon + Instagram + chat)
+
+- Decision: add `lib/intercept/security.ts` and `lib/intercept/api-response.ts` so Amazon/Instagram API routes match InnerTube error-handling posture — sanitize public reasons, never forward upstream HTML/cookie snippets, bound query/token inputs.
+  Why: Instagram errors previously included response body fragments in JSON returned to the browser; Amazon search lacked query length caps. Documented in `docs/security.md`.
+- Decision: gate Anthropic `debug_request` / `debug_final` chat SSE behind `chatDebugEventsEnabled()` (off in production unless `NEXT_PUBLIC_DEVTOOLS_ENABLED=true`).
+  Why: debug events streamed the full system prompt and tool definitions to every chat client.
+- Decision: allowlist HTTPS CDN hosts in `isAllowedOutboundImageUrl()` before server-side thumbnail fetch for multimodal chat.
+  Why: OWASP SSRF — `watching.thumbnail` is client-influenced; block internal/metadata URL fetches.
+- Decision: bump Next.js to ≥15.5.18 after `pnpm audit` reported high-severity Server Components / middleware CVEs on 15.5.15.
+  Why: supply-chain hygiene for any public deploy.

--- a/personalized-youtube/docs/intercept-adapters.md
+++ b/personalized-youtube/docs/intercept-adapters.md
@@ -39,6 +39,20 @@ The personalize panel has **YouTube | Amazon | Instagram** pills, or ask in chat
 
 If cookies or parsing fail, adapters fall back to `lib/mock-data/amazon-products.json` / `instagram-feed.json`.
 
+## Security (matches InnerTube)
+
+All intercept adapters share `lib/innertube/chrome-cookies.ts`:
+
+- **Read-only** snapshot of Chrome’s cookie DB; never write back.
+- **Never log cookie values** — count-only lines (`loaded N cookies for amazon.com`).
+- **Cookies are the server operator’s**, not the website visitor’s. Visitors cannot inject their own Amazon/IG session.
+- **No upstream bodies in API errors** — `/api/amazon/*` and `/api/instagram/*` sanitize reasons via `lib/intercept/security.ts` (Instagram used to leak HTML snippets; fixed).
+- **Input bounds** — search queries ≤256 chars, continuation tokens ≤4096 chars (same as `/api/yt/more`).
+
+TOS posture: same as YouTube intercept — educational showcase on the operator’s machine with their own logged-in Chrome profile; not a production multi-tenant service.
+
+Full audit and deploy checklist: [`security.md`](./security.md).
+
 ## Updating when sites change
 
 1. Re-capture request in DevTools (URL, headers, body).

--- a/personalized-youtube/docs/security.md
+++ b/personalized-youtube/docs/security.md
@@ -1,0 +1,78 @@
+# Security
+
+Security posture for the multi-site showcase (YouTube InnerTube + Amazon/Instagram intercept adapters).
+
+## Threat model
+
+This is an **operator-run educational showcase**, not multi-tenant production SaaS.
+
+| Actor | Access | Notes |
+|-------|--------|-------|
+| Site visitor | Chat, UI patches, public `/api/*` | Identified by `visitor_id` cookie only |
+| Server operator | Chrome cookies on disk | Amazon/IG/YouTube live feeds use **the operator's** logged-in sessions |
+| Attacker | No direct cookie DB access | Risk is SSRF, prompt leakage, API cost abuse if mis-deployed |
+
+**Safe deployments:** local dev, Vercel with `FEED_ADAPTER=mock`.  
+**Unsafe:** public URL + live intercept feeds (all visitors share operator session for upstream fetches).
+
+## Intercept adapters (YouTube, Amazon, Instagram)
+
+Shared implementation: `apps/web/lib/innertube/chrome-cookies.ts`, `apps/web/lib/intercept/`.
+
+| Control | Implementation |
+|---------|----------------|
+| Cookie values never logged | Count-only: `loaded N cookies for {domain}` |
+| Read-only cookie DB | Snapshot copy; never write back to Chrome |
+| Visitor cannot supply cookies | `fetchWithSession` uses disk cookies only |
+| API error sanitization | `lib/intercept/security.ts` → `sanitizePublicReason()` |
+| Input bounds | Query ≤256 chars; continuation token ≤4096 chars |
+| ID validation | ASIN `^[A-Z0-9]{10}$`; Instagram media id ≤64 chars |
+
+See also [`intercept-adapters.md`](./intercept-adapters.md).
+
+## Chat & multimodal
+
+| Control | Implementation |
+|---------|----------------|
+| SSRF on thumbnail fetch | `isAllowedOutboundImageUrl()` — HTTPS CDN allowlist only |
+| Debug prompt leakage | `debug_request` / `debug_final` SSE gated by `chatDebugEventsEnabled()`; off in production unless `NEXT_PUBLIC_DEVTOOLS_ENABLED=true` |
+| Visitor scoping | Patches persisted per `visitor_id` in Supabase |
+
+## Secrets & logging
+
+- `.env`, `.env.local` gitignored; service role key server-only (`supabaseAdmin`).
+- `logs/*.jsonl` gitignored (Anthropic/Gemini request metadata stays local).
+- Never commit API keys or Chrome profile directories.
+
+## Dependencies
+
+Run before deploy:
+
+```bash
+cd personalized-youtube
+pnpm audit --audit-level=high
+pnpm --filter @showcase/web build
+```
+
+Next.js is pinned to ≥15.5.18 (2026-05 security patches for Server Components / middleware).
+
+## Production checklist
+
+- [ ] `FEED_ADAPTER=mock` and `SHOWCASE_FEED_SOURCE=mock` on Vercel
+- [ ] `NEXT_PUBLIC_DEVTOOLS_ENABLED=false` (or unset) in production
+- [ ] `GEMINI_API_KEY` / `ANTHROPIC_API_KEY` in env only, not repo
+- [ ] Supabase service role never exposed to client
+- [ ] Live intercept demos run locally with operator Chrome profile only
+
+## OWASP mapping (summary)
+
+| Risk | Mitigation |
+|------|------------|
+| A01 Broken access control | Visitor patches scoped by cookie; operator cookies not visitor-controlled |
+| A02 Cryptographic failures | Secrets in env; cookies encrypted at rest in Chrome |
+| A03 Injection | Zod patches; regex-validated ASINs; no HTML injection in intercept mappers |
+| A07 Identification failures | No real auth by design; document limits |
+| A10 SSRF | CDN allowlist on chat thumbnail fetch |
+| Supply chain | `pnpm audit`, Next.js patch level |
+
+TOS posture (same as YouTube adapter): intercept on the operator's own machine with their own accounts — reasonable for showcase; production requires official APIs and OAuth.

--- a/personalized-youtube/pnpm-lock.yaml
+++ b/personalized-youtube/pnpm-lock.yaml
@@ -55,8 +55,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.1
       next:
-        specifier: ^15.0.0
-        version: 15.5.15(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        specifier: ^15.5.18
+        version: 15.5.18(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -675,56 +675,56 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
-  '@next/env@15.5.15':
-    resolution: {integrity: sha512-vcmyu5/MyFzN7CdqRHO3uHO44p/QPCZkuTUXroeUmhNP8bL5PHFEhik22JUazt+CDDoD6EpBYRCaS2pISL+/hg==}
+  '@next/env@15.5.18':
+    resolution: {integrity: sha512-hAV85Ckd9QR6RvH04MEKwsfLTksvFpO47j9xwtoIuvuPnlwecpSi+uZTtm8HirVbtlI2Fnz//xpcSTjFdyJk+g==}
 
   '@next/eslint-plugin-next@15.5.15':
     resolution: {integrity: sha512-ExQoBfyKMjAUQ2nuF39ryQsG26H374ZfH13dlOZqf6TaE9ycRbIm+qUbUFCliU4BtQhiqtS7cnGA1yWfPMQ+jA==}
 
-  '@next/swc-darwin-arm64@15.5.15':
-    resolution: {integrity: sha512-6PvFO2Tzt10GFK2Ro9tAVEtacMqRmTarYMFKAnV2vYMdwWc73xzmDQyAV7SwEdMhzmiRoo7+m88DuiXlJlGeaw==}
+  '@next/swc-darwin-arm64@15.5.18':
+    resolution: {integrity: sha512-w0WvQf1n+txiwns/9pwIQteCJpZTbxzO2SE0FLcwuD4v0WEh1JPOjdyxWL21XwJsdpx8cFRjyzxzCS/siP7HcQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@15.5.15':
-    resolution: {integrity: sha512-G+YNV+z6FDZTp/+IdGyIMFqalBTaQSnvAA+X/hrt+eaTRFSznRMz9K7rTmzvM6tDmKegNtyzgufZW0HwVzEqaQ==}
+  '@next/swc-darwin-x64@15.5.18':
+    resolution: {integrity: sha512-znn71QmDuxm+BOaglihMZfvyySMnNljkVIY5Z2TCssBmm+WqL6c19VhtH5ktFkHa8EZ2bnTUpcNcmNSQsg67og==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@15.5.15':
-    resolution: {integrity: sha512-eVkrMcVIBqGfXB+QUC7jjZ94Z6uX/dNStbQFabewAnk13Uy18Igd1YZ/GtPRzdhtm7QwC0e6o7zOQecul4iC1w==}
+  '@next/swc-linux-arm64-gnu@15.5.18':
+    resolution: {integrity: sha512-yPPe5MNL+igZUa+OsqQJisqSfh6oarIuA1Q0BDxljGJhRQyZeP+WRHh7rs/jZUGMh5aY0YdIjXZG0VohkKkUdw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@15.5.15':
-    resolution: {integrity: sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==}
+  '@next/swc-linux-arm64-musl@15.5.18':
+    resolution: {integrity: sha512-glaCczEWIrHsokFZ3pP08U4BpKxwIdnT+txdOM32OBgpL9Yw4aqx8NejmgtZQZOdstQ5f0L3CasIZudzCuD+nw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@15.5.15':
-    resolution: {integrity: sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg==}
+  '@next/swc-linux-x64-gnu@15.5.18':
+    resolution: {integrity: sha512-oUfg2EgJmU3R0OCOWiokGFUTvZiPfXtriXiuF3YNxRoROCdgvTedHIzYoeKH34gsZxS/V7mHbfq2hpAHwhH1/A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@15.5.15':
-    resolution: {integrity: sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==}
+  '@next/swc-linux-x64-musl@15.5.18':
+    resolution: {integrity: sha512-JLxSP3KTd9iu/bvUMQxH7RJo9xKSHf55/6RPE4a6FTSZygGn7uvZbCej0AHXydwkggQGSD9UddSjwv6Xz5ESfA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@15.5.15':
-    resolution: {integrity: sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A==}
+  '@next/swc-win32-arm64-msvc@15.5.18':
+    resolution: {integrity: sha512-ir1v7enP52K2HNz3tQQvwF+x7VNxBk1ciiZ18WBPvxf4C59IqdfmHPJYK3vH7rSxpuCVw/8C712wTXNAtEp+NA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@15.5.15':
-    resolution: {integrity: sha512-nFucjVdwlFqxh/JG3hWSJ4p8+YJV7Ii8aPDuBQULB6DzUF4UNZETXLfEUk+oI2zEznWWULPt7MeuTE6xtK1HSA==}
+  '@next/swc-win32-x64-msvc@15.5.18':
+    resolution: {integrity: sha512-LIu5me6QTANCd25E7I5uIEfvgQ06RK7tvHAbYo3zCb3VpxQEPvMcSpd87NwUABDT6MbGPdEGR5VRiK4PPTJhQg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -2114,8 +2114,8 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  next@15.5.15:
-    resolution: {integrity: sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ==}
+  next@15.5.18:
+    resolution: {integrity: sha512-eKL8zUJkX9Y5lE+RX/2YJoItVdGlIscyVyboeD9wSpp0PaGqjoA4tTpT2qPqz9ax+5IzGESyLSeZ/RCwbSZ2uQ==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
     hasBin: true
     peerDependencies:
@@ -3237,34 +3237,34 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@next/env@15.5.15': {}
+  '@next/env@15.5.18': {}
 
   '@next/eslint-plugin-next@15.5.15':
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@15.5.15':
+  '@next/swc-darwin-arm64@15.5.18':
     optional: true
 
-  '@next/swc-darwin-x64@15.5.15':
+  '@next/swc-darwin-x64@15.5.18':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@15.5.15':
+  '@next/swc-linux-arm64-gnu@15.5.18':
     optional: true
 
-  '@next/swc-linux-arm64-musl@15.5.15':
+  '@next/swc-linux-arm64-musl@15.5.18':
     optional: true
 
-  '@next/swc-linux-x64-gnu@15.5.15':
+  '@next/swc-linux-x64-gnu@15.5.18':
     optional: true
 
-  '@next/swc-linux-x64-musl@15.5.15':
+  '@next/swc-linux-x64-musl@15.5.18':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@15.5.15':
+  '@next/swc-win32-arm64-msvc@15.5.18':
     optional: true
 
-  '@next/swc-win32-x64-msvc@15.5.15':
+  '@next/swc-win32-x64-msvc@15.5.18':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -4200,7 +4200,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -4222,7 +4222,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7))
       hasown: 2.0.3
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -4795,9 +4795,9 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@15.5.15(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  next@15.5.18(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
-      '@next/env': 15.5.15
+      '@next/env': 15.5.18
       '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001791
       postcss: 8.4.31
@@ -4805,14 +4805,14 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
       styled-jsx: 5.1.6(react@19.2.5)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 15.5.15
-      '@next/swc-darwin-x64': 15.5.15
-      '@next/swc-linux-arm64-gnu': 15.5.15
-      '@next/swc-linux-arm64-musl': 15.5.15
-      '@next/swc-linux-x64-gnu': 15.5.15
-      '@next/swc-linux-x64-musl': 15.5.15
-      '@next/swc-win32-arm64-msvc': 15.5.15
-      '@next/swc-win32-x64-msvc': 15.5.15
+      '@next/swc-darwin-arm64': 15.5.18
+      '@next/swc-darwin-x64': 15.5.18
+      '@next/swc-linux-arm64-gnu': 15.5.18
+      '@next/swc-linux-arm64-musl': 15.5.18
+      '@next/swc-linux-x64-gnu': 15.5.18
+      '@next/swc-linux-x64-musl': 15.5.18
+      '@next/swc-win32-arm64-msvc': 15.5.18
+      '@next/swc-win32-x64-msvc': 15.5.18
       '@playwright/test': 1.59.1
       sharp: 0.34.5
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

This PR closes security gaps between Amazon/Instagram intercept adapters and the existing YouTube InnerTube path, and documents the threat model for deploy and review.

- **Shared intercept security layer** (`lib/intercept/security.ts`, `api-response.ts`) — sanitize API error reasons; never forward upstream HTML/cookie snippets to browsers
- **Instagram** — stop leaking response body fragments in `/api/instagram/*` errors; log failures server-side only
- **Amazon** — add search query length bounds (≤256); route all intercept failures through sanitization
- **Chat** — block SSRF on multimodal thumbnail fetch (HTTPS CDN allowlist); gate `debug_request` / `debug_final` SSE in production unless `NEXT_PUBLIC_DEVTOOLS_ENABLED=true`
- **Dependencies** — bump Next.js to ≥15.5.18 (`pnpm audit` high-severity CVEs on 15.5.15)
- **Documentation** — new [`docs/security.md`](personalized-youtube/docs/security.md), updates to `decisions.md`, `DEPLOY.md`, `intercept-adapters.md`, `.env.example`

## Threat model (unchanged architecture)

Live intercept feeds use the **server operator's** Chrome cookies — safe for local demo / mock-mode deploy; not multi-tenant production. See `docs/security.md`.

## YouTube impact

No changes to `lib/innertube/client.ts` or `/api/yt/*`. Chat SSRF guard applies only to multimodal thumbnail fetch; YouTube CDN hosts are allowlisted.

## Test plan

- [x] `pnpm --filter @showcase/web exec tsc --noEmit`
- [x] `pnpm audit --audit-level=high` (no high severity after Next bump)
- [ ] `GET /api/yt/search?q=test` returns videos
- [ ] `GET /api/amazon/search?q=headphones` returns products or sanitized 502
- [ ] Chat personalization still applies patches on `/`, `/amazon`, `/instagram`
- [ ] Production: confirm `FEED_ADAPTER=mock` and `NEXT_PUBLIC_DEVTOOLS_ENABLED=false`


Made with [Cursor](https://cursor.com)